### PR TITLE
Refine layout to build offline

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -24,9 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,15 +10,6 @@ export default function Home() {
   const currentUserName = useUserStore(state => state.currentUserName);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  useEffect(() => {
-    // Check if user name is already in sessionStorage
-    const savedUserName = sessionStorage.getItem('currentUserName');
-    if (savedUserName) {
-      useUserStore.getState().setCurrentUserName(savedUserName);
-    } else {
-      setIsModalOpen(true);
-    }
-  }, []);
 
   useEffect(() => {
     // Show modal if no current user name


### PR DESCRIPTION
## Summary
- remove external font loading so build works offline
- simplify user identification initialization

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e6dda63948321801d42ae766be0b6